### PR TITLE
Fix: Wrong name

### DIFF
--- a/public/api.html
+++ b/public/api.html
@@ -453,7 +453,7 @@
             </article>
             <article class="card" data-desc="This API can unshorten shortened urls">
               <a href="api/unshorten">
-                <h3>QOTD</h3>
+                <h3>Unshorten</h3>
                 <p class="card-desc">This API can unshorten shortened urls</p>
                 <p class="card-url">/unshorten?url=url</p>
               </a>


### PR DESCRIPTION
The unshorten api in the api page has the QOTD title instead of the correct one